### PR TITLE
Add google codelabs components import for polymer build

### DIFF
--- a/src/codelabs-page.html
+++ b/src/codelabs-page.html
@@ -1,5 +1,6 @@
 <link rel="import" href="../bower_components/polymer/polymer.html">
 <link rel="import" href="../bower_components/app-route/app-route.html">
+<link rel="import" href="../bower_components/codelab-components/google-codelab-elements.html">
 
 <dom-module id="codelabs-page">
 


### PR DESCRIPTION
This will pull in the needed codelab components for polymer build. I am refactoring this
page currently to improve the loading of tutorials. This will allow them
to work on staging while waiting