### PR TITLE
Add top border radius to cards

### DIFF
--- a/src/elements/codelabs-card.html
+++ b/src/elements/codelabs-card.html
@@ -32,6 +32,7 @@
         padding: 10px;
         min-height: 120px;
         color: #fff;
+        border-radius: 2px 2px 0 0;
       }
       .title {
         margin: 10px 0 0;


### PR DESCRIPTION
## Done

Add top border radius to cards

## QA

Check that the cards have a 2px border radius at the top 

Fix issue https://github.com/ubuntudesign/tutorials.ubuntu.com/issues/24