### PR TITLE
Fix #28 bottom-padding should be 46px

### DIFF
--- a/src/elements/codelabs-card.html
+++ b/src/elements/codelabs-card.html
@@ -57,14 +57,9 @@
         width: 100%;
       }
       .card-actions {
-        bottom: 0;
-        top: auto;
         box-sizing: border-box;
-        margin-top: 5px;
-        position: relative;
         width: 100%;
-        height: 100%;
-        padding: 10px;
+        line-height: 2;
       }
       a {
         text-decoration: none;


### PR DESCRIPTION
## Done

Fix #28 bottom-padding should be 46px

Bottom padding (height) to be consistent

Check staging in Chrome and you’ll see that the bottom section of the cards, (the level and duration bit) is 36px high, this is wrong, it should be 46px which is the same as Safari. It is now.
 