### PR TITLE
card should fit 100% width on mobile when in 1 col

### DIFF
--- a/src/codelabs-index.html
+++ b/src/codelabs-index.html
@@ -50,11 +50,11 @@
       }
       codelabs-card {
         margin: 10px;
-        max-width: 306px;
+        max-width: 100%;
       }
-      @media only screen and (max-width: 768px) {
+      @media only screen and (min-width: 768px) {
         codelabs-card {
-          max-width: 354px;
+          max-width: 306px;
         }
       }
       .event-wrapper {


### PR DESCRIPTION
## Done

Make cards 100% width whenst is small

Fixes issue https://github.com/ubuntudesign/tutorials.ubuntu.com/issues/15