### PR TITLE
Intro copy link needs external icon

### DIFF
--- a/src/codelabs-index.html
+++ b/src/codelabs-index.html
@@ -33,7 +33,7 @@
       }
       .intro {
         font-family: 'Ubuntu',Helvetica,Arial;
-        max-width: 700px;
+        max-width: 620px;
         padding-left: 10px;
         padding-bottom: 40px;
       }
@@ -42,7 +42,6 @@
         font-weight: 300;
       }
       .intro p {
-        font-size: 20px;
         font-weight: 300;
       }
       .intro a {
@@ -67,6 +66,12 @@
       .event-description {
         margin-left: 20px;
       }
+      a.codelabs-index {
+        text-decoration: none;
+      }
+      a.codelabs-index:hover {
+        text-decoration: underline;
+      }
     </style>
 
     <div>
@@ -84,7 +89,7 @@
           <h1>Let's get coding!</h1>
           <p>Ubuntu Tutorials are just like learning from pair programming except you can do it on your own. They provide a step-by-step process to doing development and devops activities on Ubuntu machines, servers or devices.</p>
 
-          <p>For now, the tutorials focus mainly on building and using snaps and Ubuntu Core. <a href="https://github.com/ubuntudesign/tutorials.ubuntu.com/issues/new" class="external">If you'd like to see tutorials cover more topics, let us know.</a></p>
+          <p>For now, the tutorials focus mainly on building and using snaps and Ubuntu Core.<br /><a href="https://github.com/ubuntudesign/tutorials.ubuntu.com/issues/new" class="external">If you'd like to see tutorials cover more topics, let us know.</a></p>
         </div>
         <div class="horizontal layout end">
           <div class="flex"></div>

--- a/src/codelabs-index.html
+++ b/src/codelabs-index.html
@@ -72,6 +72,13 @@
       a.codelabs-index:hover {
         text-decoration: underline;
       }
+    .external {
+        background-image: url("https://assets.ubuntu.com/v1/f24a8aa0-external-link-orange.svg");
+        background-position: 100% top;
+        background-repeat: no-repeat;
+        background-size: 0.7em 0.7em;
+        padding-right: 0.9em;
+    }    
     </style>
 
     <div>
@@ -89,7 +96,7 @@
           <h1>Let's get coding!</h1>
           <p>Ubuntu Tutorials are just like learning from pair programming except you can do it on your own. They provide a step-by-step process to doing development and devops activities on Ubuntu machines, servers or devices.</p>
 
-          <p>For now, the tutorials focus mainly on building and using snaps and Ubuntu Core.<br /><a href="https://github.com/ubuntudesign/tutorials.ubuntu.com/issues/new" class="external">If you'd like to see tutorials cover more topics, let us know.</a></p>
+          <p>For now, the tutorials focus mainly on building and using snaps and Ubuntu Core.<br /><a href="https://github.com/ubuntudesign/tutorials.ubuntu.com/issues/new" class="external">If you'd like to see tutorials cover more topics, let us know</a></p>
         </div>
         <div class="horizontal layout end">
           <div class="flex"></div>


### PR DESCRIPTION
## Done

Add external icon
Make intro normal paragraph font size
Make link live on its’ own line

Fix issue https://github.com/ubuntudesign/tutorials.ubuntu.com/issues/33