### PR TITLE
Remove service worker while we work on stability

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,12 +48,6 @@
         document.head.appendChild(e);
       }
     })();
-    // load pre-caching service worker
-    if ('serviceWorker' in navigator) {
-      window.addEventListener('load', function() {
-        navigator.serviceWorker.register('/service-worker.js');
-      });
-    }
   </script>
 
   <link rel="import" href="/src/ubuntu-tutorials-app.html">


### PR DESCRIPTION
We are having some problems with the service worker on Firefox.
Temporarily disable it while we look into the solution