### PR TITLE
basic-snap-usage: add missing space before links

### DIFF
--- a/src/codelabs/basic-snap-usage/index.ubuntu-template.html
+++ b/src/codelabs/basic-snap-usage/index.ubuntu-template.html
@@ -107,14 +107,14 @@ $ sudo setenforce 0
 
 # to persist, edit /etc/selinux/config to set SELINUX=permissive and reboot.</pre>
 <h3>Gentoo</h3>
-<p>Install the<a href="https://github.com/zyga/gentoo-snappy" target="_blank">gentoo-snappy overlay</a>.</p>
+<p>Install the <a href="https://github.com/zyga/gentoo-snappy" target="_blank">gentoo-snappy overlay</a>.</p>
 <h3>OpenEmbedded/Yocto</h3>
-<p>Install the<a href="https://github.com/morphis/meta-snappy/blob/master/README.md" target="_blank">snap meta layer</a>.</p>
+<p>Install the <a href="https://github.com/morphis/meta-snappy/blob/master/README.md" target="_blank">snap meta layer</a>.</p>
 <h3>openSuSE</h3>
 <pre>$ sudo zypper addrepo http://download.opensuse.org/repositories/system:/snappy/openSUSE_Leap_42.2/ snappy
 $ sudo zypper install snapd</pre>
 <h3>OpenWrt</h3>
-<p>Enable the<a href="https://github.com/teknoraver/snap-openwrt/blob/master/README.md" target="_blank">snap-openwrt feed</a>.</p>
+<p>Enable the <a href="https://github.com/teknoraver/snap-openwrt/blob/master/README.md" target="_blank">snap-openwrt feed</a>.</p>
 <h3>Ubuntu</h3>
 <p>You should already be all set on ubuntu 16.04 LTS desktop, just in case run:</p>
 <pre>$ sudo apt install snapd</pre>


### PR DESCRIPTION
Add missing spaces into the html template of basic-snap-usage.
This issue was not found in other pages with command:
grep -r "[0-9a-zA-Z]<a " *.html

This fixes #68

Signed-off-by: Po-Hsu Lin <po-hsu.lin@canonical.com>